### PR TITLE
refactor(switch-env): switch-env now uses the [env].default value from the config

### DIFF
--- a/bin/commands/switch-env.js
+++ b/bin/commands/switch-env.js
@@ -10,17 +10,17 @@ exports.define = function (program) {
     .option('-e --environment [environment]', 'environment to be logged in to')
     .option('-u --username [username]', 'username for your appc account')
     .option('-p --password [password', 'password for your appc account')
-    .option('-o --orgId [org-id]', 'org to log in to, by default will be the team org for each env')
+    .option('-o --orgId [org-id]', 'org to log in to, by default will be the default org for each env set in your config')
     .action(function (command) {
       var orgId;
       if (command.orgId === undefined && command.environment != undefined) {
         if(/^prod/.test(command.environment)) {
-          var prodOrg = config.get('prod.team');
+          var prodOrg = config.get('prod.default');
           if(prodOrg != undefined) {
             orgId = prodOrg;
           }
         } else {
-          var preprodOrg = config.get('preprod.team');
+          var preprodOrg = config.get('preprod.default');
           if(preprodOrg != undefined) {
             orgId = preprodOrg;
           }

--- a/lib/commands/switch-env.js
+++ b/lib/commands/switch-env.js
@@ -9,7 +9,7 @@ var config = require('./config');
 
 function getOrgId() {
   return function(answers) {
-    return config.get(answers.environment+'.team');
+    return config.get(answers.environment+'.default');
   };
 }
 


### PR DESCRIPTION
Closes #15
